### PR TITLE
nil fan_state support and handling of HVAC_state

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -315,17 +315,39 @@ function Parse(data)
         }
 
         C4:SendToProxy(5001, "FAN_STATE_CHANGED", tParams, "NOTIFY")
+    else
+        local hvacActionValue = attributes["hvac_action"]
+        local fanModeValue = attributes["fan_mode"]
+        local fanStateString = ""
+        if ((not string.find(hvacActionValue, "idle")) or (string.find(fanModeValue, "on"))) then
+            fanStateString = "On"
+        else
+            fanStateString = "Off"
+        end
+
+        local tParams = {
+            STATE = fanStateString
+        }
+
+        C4:SendToProxy(5001, "FAN_STATE_CHANGED", tParams, "NOTIFY")
     end
+
 
     if attributes["hvac_action"] ~= nil then
         local value = attributes["hvac_action"]
-
+        local c4ReportableState = ""
+        if(string.find(value, "cool")) then c4ReportableState = "Cool"
+            else if(string.find(value, "heat")) then c4ReportableState = "Heat" 
+        else c4ReportableState = "Off"
+        end
+    end
         local tParams = {
-            STATE = value
+            STATE = c4ReportableState
         }
 
         C4:SendToProxy(5001, "HVAC_STATE_CHANGED", tParams, "NOTIFY")
     end
+
 
     if state ~= nil then
         MODE = state

--- a/driver.xml
+++ b/driver.xml
@@ -69,6 +69,7 @@
 		<setpoint_single_max_f>90</setpoint_single_max_f>
 		<setpoint_single_max_c>32</setpoint_single_max_c>
 		<fan_states>Off,On</fan_states>
+		<hvac_states>Off,Heat,Cool</hvac_states>
 		<has_connection_status>true</has_connection_status>
 		<current_temperature_resolution_f>1</current_temperature_resolution_f>
 		<current_temperature_resolution_c>1</current_temperature_resolution_c>


### PR DESCRIPTION
Added fan state support for HA entities that do not expose a fan_state attribute in HA (Ecobee). Also implemented HVAC state for rich icons and active state tracking in C4.